### PR TITLE
Added DisconnectAsync, use this when becoming disconnected from the s…

### DIFF
--- a/src/SuperSimpleTcp/SimpleTcpClient.cs
+++ b/src/SuperSimpleTcp/SimpleTcpClient.cs
@@ -658,6 +658,25 @@ namespace SuperSimpleTcp
         }
 
         /// <summary>
+        /// Disconnect from the server.
+        /// </summary>
+        public async Task DisconnectAsync()
+        {
+            if (!IsConnected)
+            {
+                Logger?.Invoke($"{_header}already disconnected");
+                return;
+            }
+
+            Logger?.Invoke($"{_header}disconnecting from {ServerIpPort}");
+
+            _tokenSource.Cancel();
+            await _dataReceiver;
+            _client.Close();
+            _isConnected = false;
+        }
+
+        /// <summary>
         /// Send data to the server.
         /// </summary>
         /// <param name="data">String containing data to send.</param>
@@ -958,7 +977,7 @@ namespace SuperSimpleTcp
 
                     if (!isOk)
                     {
-                        this.Disconnect();
+                        await this.DisconnectAsync();
                     }
 
                     throw new SocketException();


### PR DESCRIPTION
I noticed that when my client program was disconnected from the server. (This was caused by the program running on the server closing) My program would usually hang. When I did a Break and looked at the Tasks it showed that a cycle was detected.

Looking into the code I believe I've found the issue. Inside the DataReceiver Task it calls DataReadAsync. Inside DataReadAsync if we read zero bytes from the stream, it checks the tcpConnections. If the connection is not ok it calls this.Disconnect. Inside the Disconnect function it does _dataReceiver.Wait(). The Disconnect function is waiting for the DataReceiver Task to finish, but the DataReceiver Task is blocked waiting for control to come back from Disconnect, hence the deadlock.

Changing these to be awaits instead of waits solves the issue.