### PR TITLE
Future proof keepalive settings

### DIFF
--- a/src/SuperSimpleTcp/SimpleTcpClient.cs
+++ b/src/SuperSimpleTcp/SimpleTcpClient.cs
@@ -1070,7 +1070,7 @@ namespace SuperSimpleTcp
         {
             try
             {
-#if NETCOREAPP || NET5_0
+#if NETCOREAPP || NET5_0_OR_GREATER
 
                 _client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 _client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, _keepalive.TcpKeepAliveTime);

--- a/src/SuperSimpleTcp/SimpleTcpServer.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServer.cs
@@ -1110,7 +1110,7 @@ namespace SuperSimpleTcp
         {
             try
             {
-#if NETCOREAPP || NET5_0
+#if NETCOREAPP || NET5_0_OR_GREATER
 
                 _listener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 _listener.Server.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, _keepalive.TcpKeepAliveTime);
@@ -1147,7 +1147,7 @@ namespace SuperSimpleTcp
         {
             try
             {
-#if NETCOREAPP || NET5_0
+#if NETCOREAPP || NET5_0_OR_GREATER
 
                 client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, _keepalive.TcpKeepAliveTime);


### PR DESCRIPTION
I noticed the keepalive settings wouldn't take effect if the library user targets NET6+. As per https://docs.microsoft.com/en-us/dotnet/standard/frameworks I've changed `NET5_0` to `NET5_0_OR_GREATER`. This should future proof any NETx targets.