### PR TITLE
Reducing memory allocations for receiving data

### DIFF
--- a/src/ClientTest/Client.cs
+++ b/src/ClientTest/Client.cs
@@ -109,7 +109,7 @@ namespace ClientTest
 
         static void DataReceived(object sender, DataReceivedEventArgs e)
         {
-            Console.WriteLine("[" + e.IpPort + "] " + Encoding.UTF8.GetString(e.Data));
+            Console.WriteLine("[" + e.IpPort + "] " + Encoding.UTF8.GetString(e.Data.Array, 0, e.Data.Count));
         }
 
         private static void DataSent(object sender, DataSentEventArgs e)

--- a/src/ServerTest/Server.cs
+++ b/src/ServerTest/Server.cs
@@ -115,7 +115,7 @@ namespace ServerTest
 
         static void DataReceived(object sender, DataReceivedEventArgs e)
         {
-            Console.WriteLine("[" + e.IpPort + "]: " + Encoding.UTF8.GetString(e.Data));
+            Console.WriteLine("[" + e.IpPort + "]: " + Encoding.UTF8.GetString(e.Data.Array, 0, e.Data.Count));
         }
 
         private static void DataSent(object sender, DataSentEventArgs e)

--- a/src/SuperSimpleTcp/DataReceivedEventArgs.cs
+++ b/src/SuperSimpleTcp/DataReceivedEventArgs.cs
@@ -7,7 +7,7 @@ namespace SuperSimpleTcp
     /// </summary>
     public class DataReceivedEventArgs : EventArgs
     {
-        internal DataReceivedEventArgs(string ipPort, byte[] data)
+        internal DataReceivedEventArgs(string ipPort, ArraySegment<byte> data)
         {
             IpPort = ipPort;
             Data = data;
@@ -21,6 +21,6 @@ namespace SuperSimpleTcp
         /// <summary>
         /// The data received from the endpoint.
         /// </summary>
-        public byte[] Data { get; }
+        public ArraySegment<byte> Data { get; }
     }
 }

--- a/src/SuperSimpleTcp/SimpleTcpClient.cs
+++ b/src/SuperSimpleTcp/SimpleTcpClient.cs
@@ -849,21 +849,21 @@ namespace SuperSimpleTcp
                 {
                     await DataReadAsync(token).ContinueWith(async task =>
                         {
-                            if (task.IsCanceled) return null;
-                            byte[] data = task.Result;
+                            if (task.IsCanceled) return default;
+                            var data = task.Result;
 
                             if (data != null)
                             {
                                 _lastActivity = DateTime.Now;
                                 _events.HandleDataReceived(this, new DataReceivedEventArgs(ServerIpPort, data));
-                                _statistics.ReceivedBytes += data.Length;
+                                _statistics.ReceivedBytes += data.Count;
 
                                 return data;
                             }
                             else
                             {
                                 await Task.Delay(100).ConfigureAwait(false);
-                                return null;
+                                return default;
                             }
 
                         }, token).ContinueWith(task => { }).ConfigureAwait(false);
@@ -915,7 +915,7 @@ namespace SuperSimpleTcp
             Dispose();
         }
 
-        private async Task<byte[]> DataReadAsync(CancellationToken token)
+        private async Task<ArraySegment<byte>> DataReadAsync(CancellationToken token)
         {
             byte[] buffer = new byte[_settings.StreamBufferSize];
             int read = 0;
@@ -936,7 +936,7 @@ namespace SuperSimpleTcp
                     using (MemoryStream ms = new MemoryStream())
                     {
                         ms.Write(buffer, 0, read);
-                        return ms.ToArray();
+                        return new ArraySegment<byte>(ms.GetBuffer(), 0, (int)ms.Length);
                     }
                 }
                 else
@@ -969,7 +969,7 @@ namespace SuperSimpleTcp
                 // thrown if ReadTimeout (ms) is exceeded
                 // see https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.networkstream.readtimeout?view=net-6.0
                 // and https://github.com/dotnet/runtime/issues/24093
-                return null;
+                return default;
             }
         }
 

--- a/src/SuperSimpleTcp/SimpleTcpServer.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServer.cs
@@ -859,7 +859,7 @@ namespace SuperSimpleTcp
                         break;
                     } 
 
-                    byte[] data = await DataReadAsync(client, linkedCts.Token).ConfigureAwait(false);
+                    var data = await DataReadAsync(client, linkedCts.Token).ConfigureAwait(false);
                     if (data == null)
                     {
                         await Task.Delay(10, linkedCts.Token).ConfigureAwait(false);
@@ -867,7 +867,7 @@ namespace SuperSimpleTcp
                     }
 
                     _ = Task.Run(() => _events.HandleDataReceived(this, new DataReceivedEventArgs(ipPort, data)), linkedCts.Token);
-                    _statistics.ReceivedBytes += data.Length;
+                    _statistics.ReceivedBytes += data.Count;
                     UpdateClientLastSeen(client.IpPort);
                 }
                 catch (IOException)
@@ -920,7 +920,7 @@ namespace SuperSimpleTcp
             if (client != null) client.Dispose();
         }
            
-        private async Task<byte[]> DataReadAsync(ClientMetadata client, CancellationToken token)
+        private async Task<ArraySegment<byte>> DataReadAsync(ClientMetadata client, CancellationToken token)
         { 
             byte[] buffer = new byte[_settings.StreamBufferSize];
             int read = 0;
@@ -936,7 +936,7 @@ namespace SuperSimpleTcp
                         if (read > 0)
                         {
                             await ms.WriteAsync(buffer, 0, read, token).ConfigureAwait(false);
-                            return ms.ToArray();
+                            return new ArraySegment<byte>(ms.GetBuffer(), 0, (int)ms.Length);
                         }
                         else
                         {
@@ -956,7 +956,7 @@ namespace SuperSimpleTcp
                         if (read > 0)
                         {
                             await ms.WriteAsync(buffer, 0, read, token).ConfigureAwait(false);
-                            return ms.ToArray();
+                            return new ArraySegment<byte>(ms.GetBuffer(), 0, (int)ms.Length);
                         }
                         else
                         {


### PR DESCRIPTION
For both Client and Server:

Breaking Change:

DataReceivedEventArgs now return an ArraySegment that directly refers to the internal MemoryStream removing one unnecessary allocation per receive.

this is in line with https://github.com/jchristn/WatsonWebsocket/pull/95