### PR TITLE
Add X509Certificate2 to InitializeClient

### DIFF
--- a/src/SuperSimpleTcp/SimpleTcpClient.cs
+++ b/src/SuperSimpleTcp/SimpleTcpClient.cs
@@ -432,7 +432,7 @@ namespace SuperSimpleTcp
             else
             {
                 Logger?.Invoke($"{_header}initializing client");
-                InitializeClient(_ssl, _pfxCertFilename, _pfxPassword);
+                InitializeClient(_ssl, _pfxCertFilename, _pfxPassword, _sslCert);
                 Logger?.Invoke($"{_header}connecting to {ServerIpPort}");
             }
 
@@ -523,7 +523,7 @@ namespace SuperSimpleTcp
             {
                 Logger?.Invoke($"{_header}initializing client");
 
-                InitializeClient(_ssl, _pfxCertFilename, _pfxPassword);
+                InitializeClient(_ssl, _pfxCertFilename, _pfxPassword, _sslCert);
 
                 Logger?.Invoke($"{_header}connecting to {ServerIpPort}");
             }
@@ -823,7 +823,7 @@ namespace SuperSimpleTcp
             }
         }
 
-        private void InitializeClient(bool ssl, string pfxCertFilename, string pfxPassword)
+        private void InitializeClient(bool ssl, string pfxCertFilename, string pfxPassword, X509Certificate2 sslCert)
         {
             _ssl = ssl;
             _pfxCertFilename = pfxCertFilename;
@@ -835,7 +835,11 @@ namespace SuperSimpleTcp
 
             if (_ssl)
             {
-                if (string.IsNullOrEmpty(pfxPassword))
+                if (sslCert != null)
+                {
+                    _sslCert = sslCert;
+                }
+                else if (string.IsNullOrEmpty(pfxPassword))
                 {
                     _sslCert = new X509Certificate2(pfxCertFilename);
                 }


### PR DESCRIPTION
SimpleTcpClient did accept X509Certificate, but when it was being initialized it wasn't being passed on to the InitializeClient method.

Now it checks if there is a certificate and if so, puts it into the collection, skipping the creation.