### PR TITLE
- add settings parameter "ClientCertificateValidationCallback/ServerC…

### DIFF
--- a/src/SuperSimpleTcp/SimpleTcp.xml
+++ b/src/SuperSimpleTcp/SimpleTcp.xml
@@ -396,6 +396,16 @@
             Enable or disable mutual authentication of SSL client and server.
             </summary>
         </member>
+        <member name="F:SuperSimpleTcp.SimpleTcpClientSettings.CheckCertificateRevocation">
+            <summary>
+            Enable or disable checking the certificate revocation list during the certificate validation process.
+            </summary>
+        </member>
+        <member name="F:SuperSimpleTcp.SimpleTcpClientSettings.ServerCertificateValidationCallback">
+            <summary>
+            Gets or sets a RemoteCertificateValidationCallback delegate that's responsible for validating the certificate supplied by the remote party.
+            </summary>
+        </member>
         <member name="M:SuperSimpleTcp.SimpleTcpClientSettings.#ctor">
             <summary>
             Instantiate the object.
@@ -682,6 +692,16 @@
         <member name="F:SuperSimpleTcp.SimpleTcpServerSettings.MutuallyAuthenticate">
             <summary>
             Enable or disable mutual authentication of SSL client and server.
+            </summary>
+        </member>
+        <member name="F:SuperSimpleTcp.SimpleTcpServerSettings.CheckCertificateRevocation">
+            <summary>
+            Enable or disable checking the certificate revocation list during the certificate validation process.
+            </summary>
+        </member>
+        <member name="F:SuperSimpleTcp.SimpleTcpServerSettings.ClientCertificateValidationCallback">
+            <summary>
+            Gets or sets a RemoteCertificateValidationCallback delegate that's responsible for validating the certificate supplied by the remote party.
             </summary>
         </member>
         <member name="P:SuperSimpleTcp.SimpleTcpServerSettings.PermittedIPs">

--- a/src/SuperSimpleTcp/SimpleTcpClient.cs
+++ b/src/SuperSimpleTcp/SimpleTcpClient.cs
@@ -479,10 +479,13 @@ namespace SuperSimpleTcp
                     if (_settings.AcceptInvalidCertificates)
                         _sslStream = new SslStream(_networkStream, false, new RemoteCertificateValidationCallback(AcceptCertificate));
                     else
+                    if (_settings.ServerCertificateValidationCallback != null)
+                        _sslStream = new SslStream(_networkStream, false, new RemoteCertificateValidationCallback(_settings.ServerCertificateValidationCallback));
+                    else
                         _sslStream = new SslStream(_networkStream, false);
 
                     _sslStream.ReadTimeout = _settings.ReadTimeoutMs;
-                    _sslStream.AuthenticateAsClient(_serverIp, _sslCertCollection, SslProtocols.Tls12, !_settings.AcceptInvalidCertificates);
+                    _sslStream.AuthenticateAsClient(_serverIp, _sslCertCollection, SslProtocols.Tls12, _settings.CheckCertificateRevocation);
 
                     if (!_sslStream.IsEncrypted) throw new AuthenticationException("Stream is not encrypted");
                     if (!_sslStream.IsAuthenticated) throw new AuthenticationException("Stream is not authenticated");
@@ -610,10 +613,13 @@ namespace SuperSimpleTcp
                         if (_settings.AcceptInvalidCertificates)
                             _sslStream = new SslStream(_networkStream, false, new RemoteCertificateValidationCallback(AcceptCertificate));
                         else
+                        if (_settings.ServerCertificateValidationCallback != null)
+                            _sslStream = new SslStream(_networkStream, false, new RemoteCertificateValidationCallback(_settings.ServerCertificateValidationCallback));
+                        else
                             _sslStream = new SslStream(_networkStream, false);
 
                         _sslStream.ReadTimeout = _settings.ReadTimeoutMs;
-                        _sslStream.AuthenticateAsClient(_serverIp, _sslCertCollection, SslProtocols.Tls12, !_settings.AcceptInvalidCertificates);
+                        _sslStream.AuthenticateAsClient(_serverIp, _sslCertCollection, SslProtocols.Tls12, _settings.CheckCertificateRevocation);
 
                         if (!_sslStream.IsEncrypted) throw new AuthenticationException("Stream is not encrypted");
                         if (!_sslStream.IsAuthenticated) throw new AuthenticationException("Stream is not authenticated");

--- a/src/SuperSimpleTcp/SimpleTcpClientSettings.cs
+++ b/src/SuperSimpleTcp/SimpleTcpClientSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Security;
 
 namespace SuperSimpleTcp
 {
@@ -118,6 +119,16 @@ namespace SuperSimpleTcp
         /// Enable or disable mutual authentication of SSL client and server.
         /// </summary>
         public bool MutuallyAuthenticate = true;
+
+        /// <summary>
+        /// Enable or disable checking the certificate revocation list during the certificate validation process.
+        /// </summary>
+        public bool CheckCertificateRevocation = true;
+
+        /// <summary>
+        /// Gets or sets a RemoteCertificateValidationCallback delegate that's responsible for validating the certificate supplied by the remote party.
+        /// </summary>
+        public RemoteCertificateValidationCallback ServerCertificateValidationCallback = null;
 
         #endregion
 

--- a/src/SuperSimpleTcp/SimpleTcpServer.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServer.cs
@@ -750,6 +750,11 @@ namespace SuperSimpleTcp
                             client.SslStream = new SslStream(client.NetworkStream, false, new RemoteCertificateValidationCallback(AcceptCertificate));
                         }
                         else
+                        if (_settings.ClientCertificateValidationCallback != null)
+                        {
+                            client.SslStream = new SslStream(client.NetworkStream, false, new RemoteCertificateValidationCallback(_settings.ClientCertificateValidationCallback));
+                        }
+                        else
                         {
                             client.SslStream = new SslStream(client.NetworkStream, false);
                         }
@@ -815,7 +820,7 @@ namespace SuperSimpleTcp
                     _sslCertificate,
                     _settings.MutuallyAuthenticate,
                     SslProtocols.Tls12,
-                    !_settings.AcceptInvalidCertificates).ConfigureAwait(false);
+                    _settings.CheckCertificateRevocation).ConfigureAwait(false);
 
                 if (!client.SslStream.IsEncrypted)
                 {

--- a/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Security;
 
 namespace SuperSimpleTcp
 {
@@ -88,6 +89,16 @@ namespace SuperSimpleTcp
         /// Enable or disable mutual authentication of SSL client and server.
         /// </summary>
         public bool MutuallyAuthenticate = true;
+
+        /// <summary>
+        /// Enable or disable checking the certificate revocation list during the certificate validation process.
+        /// </summary>
+        public bool CheckCertificateRevocation = true;
+
+        /// <summary>
+        /// Gets or sets a RemoteCertificateValidationCallback delegate that's responsible for validating the certificate supplied by the remote party.
+        /// </summary>
+        public RemoteCertificateValidationCallback ClientCertificateValidationCallback = null;
 
         /// <summary>
         /// The list of permitted IP addresses from which connections can be received.


### PR DESCRIPTION
- add settings parameter "ClientCertificateValidationCallback/ServerCertificateValidationCallback" to set a custom a RemoteCertificateValidationCallback delegate that's responsible for validating the certificate supplied by the remote party

- add settings parameter "CheckCertificateRevocation" to enable or disable checking the certificate revocation list during the certificate validation process.