### PR TITLE
Settings for DataReceived on background worker

### DIFF
--- a/src/SuperSimpleTcp.UnitTest/ServerSettingsTest.cs
+++ b/src/SuperSimpleTcp.UnitTest/ServerSettingsTest.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SuperSimpleTcp.UnitTest
+{
+    [TestClass]
+    public class ServerSettingsTest
+    {
+        [TestMethod]
+        public async Task UseHandleDataReceivedWorkerTask_Enabled_DifferentThreads()
+        {
+            TestDataReceiver dataReceiver = new ();
+
+            using var simpleTcpServer = new SimpleTcpServer("127.0.0.1", 50000);
+            simpleTcpServer.Settings.UseHandleDataReceivedWorkerTask = true;
+            simpleTcpServer.Events.DataReceived += dataReceiver.DataReceived;
+            simpleTcpServer.Start();
+
+            using var simpleTcpClient = new SimpleTcpClient("127.0.0.1", 50000);
+            simpleTcpClient.Connect();
+
+            // Send some data
+            for (int i = 0; i < 100; i++)
+            {
+                simpleTcpClient.SendAsync($"Message {i}");
+                await Task.Delay(10);
+            }
+
+            // Wait before closing the server
+            await Task.Delay(1000);
+
+            simpleTcpClient.Disconnect();
+            simpleTcpServer.Stop();
+
+            // Check if the thread ids were all the same
+            Assert.IsTrue(dataReceiver.CallingThreadIds.Distinct().Count() != 1);
+        }
+
+        [TestMethod]
+        public async Task UseHandleDataReceivedWorkerTask_Disable_SameThread()
+        {
+            TestDataReceiver dataReceiver = new();
+
+            using var simpleTcpServer = new SimpleTcpServer("127.0.0.1", 50000);
+            simpleTcpServer.Settings.UseHandleDataReceivedWorkerTask = false;
+            simpleTcpServer.Events.DataReceived += dataReceiver.DataReceived;
+            simpleTcpServer.Start();
+
+            using var simpleTcpClient = new SimpleTcpClient("127.0.0.1", 50000);
+            simpleTcpClient.Connect();
+
+            // Send some data
+            for (int i = 0; i < 100; i++)
+            {
+                simpleTcpClient.SendAsync($"Message {i}");
+                await Task.Delay(10);
+            }
+
+            // Wait before closing the server
+            await Task.Delay(1000);
+
+            simpleTcpClient.Disconnect();
+            simpleTcpServer.Stop();
+
+            // Check if the thread ids were different
+            Assert.IsTrue(dataReceiver.CallingThreadIds.Distinct().Count() == 1);
+        }
+
+        /// <summary>
+        /// Test class that captures the thread identifiers when the DataReceived method is called.
+        /// </summary>
+        private class TestDataReceiver
+        {
+            private readonly List<int> _callingThreads = new();
+
+            /// <summary>
+            /// Gets the calling thread ids.
+            /// </summary>
+            /// <value>The calling thread ids.</value>
+            public List<int> CallingThreadIds => _callingThreads;
+
+            public void DataReceived(object? sender, DataReceivedEventArgs args)
+            {
+                // Get current thread id
+                lock (_callingThreads)
+                {
+                    CallingThreadIds.Add(Thread.CurrentThread.ManagedThreadId);
+                }
+            }
+        }
+    }
+}

--- a/src/SuperSimpleTcp/SimpleTcp.xml
+++ b/src/SuperSimpleTcp/SimpleTcp.xml
@@ -684,6 +684,12 @@
             Enable or disable mutual authentication of SSL client and server.
             </summary>
         </member>
+        <member name="F:SuperSimpleTcp.SimpleTcpServerSettings.UseHandleDataReceivedWorkerTask">
+            <summary>
+            Enable or disable whether the data receiver thread fires the DataReceived event from a background task.
+            The default is enabled.
+            </summary>
+        </member>
         <member name="P:SuperSimpleTcp.SimpleTcpServerSettings.PermittedIPs">
             <summary>
             The list of permitted IP addresses from which connections can be received.

--- a/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
@@ -90,6 +90,12 @@ namespace SuperSimpleTcp
         public bool MutuallyAuthenticate = true;
 
         /// <summary>
+        /// Enable or disable whether the data receiver thread fires the DataReceived event from a background task.
+        /// The default is enabled.
+        /// </summary>
+        public bool UseHandleDataReceivedWorkerTask = true;
+
+        /// <summary>
         /// The list of permitted IP addresses from which connections can be received.
         /// </summary>
         public List<string> PermittedIPs


### PR DESCRIPTION
Added a setting that allows the user to control whether the DataReceived event is fired in a background worker or in the DataRecevier thread.

Added unit tests for this setting.