### PR TITLE
- use CheckCertificateRevocation instead of AcceptInvalidCertificates…

### DIFF
--- a/src/SuperSimpleTcp/SimpleTcpServer.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServer.cs
@@ -822,7 +822,7 @@ namespace SuperSimpleTcp
                     _sslCertificate,
                     _settings.MutuallyAuthenticate,
                     SslProtocols.Tls12,
-                    !_settings.AcceptInvalidCertificates).ConfigureAwait(false);
+                    _settings.CheckCertificateRevocation).ConfigureAwait(false);
 
                 if (!client.SslStream.IsEncrypted)
                 {


### PR DESCRIPTION
use CheckCertificateRevocation instead of AcceptInvalidCertificates in SimpleTcpServer because when using custom certificate validation AcceptInvalidCertificates needs to be false resulting in an enabled revocation check but these revocation check might fail and therefore should also be handled in custom validation