### PR TITLE
fix: handle canceled task on disconnect

### DIFF
--- a/src/SuperSimpleTcp.UnitTest/IntegrationTest.cs
+++ b/src/SuperSimpleTcp.UnitTest/IntegrationTest.cs
@@ -47,7 +47,7 @@ namespace SuperSimpleTcp.UnitTest
         public async Task Start_StartServerAndConnectWithOneClientAndSendMessages_Successful()
         {
             var ipAddress = "127.0.0.1";
-            var port = 8000;
+            var port = 8001;
             var testData = StringHelper.RandomString(1000);
             var acknowledgeData = Encoding.UTF8.GetBytes("acknowledge");
 

--- a/src/SuperSimpleTcp.UnitTest/ServerTest.cs
+++ b/src/SuperSimpleTcp.UnitTest/ServerTest.cs
@@ -34,7 +34,7 @@ namespace SuperSimpleTcp.UnitTest
             var certificateFilePath = "simpletcp.crt";
             TestCertificateHelper.CreateCertificate(certificateFilePath);
 
-            using var simpleTcpServer = new SimpleTcpServer("127.0.0.1", 8001, true, certificateFilePath, "simpletcp");
+            using var simpleTcpServer = new SimpleTcpServer("127.0.0.1", 8003, true, certificateFilePath, "simpletcp");
             simpleTcpServer.Start();
             Assert.IsTrue(simpleTcpServer.IsListening);
         }


### PR DESCRIPTION
The solution to the issue when `TaskCanceledException ` is raised while trying to await the `DataReceiver` task in Disconnect/DisconnectAsync. The problem was that `_tokenSource.Cancel();` was canceled just before the wait statement. To solve it, a try-catch for `TaskCanceledException` was added.

There was also a small change in the tests to set various ports, since the tests have been failing occasionally due to `SocketException: Address already in use`