### PR TITLE
Expose server port

### DIFF
--- a/src/SuperSimpleTcp/SimpleTcp.xml
+++ b/src/SuperSimpleTcp/SimpleTcp.xml
@@ -499,6 +499,11 @@
             Retrieve the number of current connected clients.
             </summary>
         </member>
+        <member name="P:SuperSimpleTcp.SimpleTcpServer.Port">
+            <summary>
+            The port that the server is running on
+            </summary>
+        </member>
         <member name="F:SuperSimpleTcp.SimpleTcpServer.Logger">
             <summary>
             Method to invoke to send a log message.

--- a/src/SuperSimpleTcp/SimpleTcpServer.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServer.cs
@@ -107,6 +107,17 @@ namespace SuperSimpleTcp
         }
 
         /// <summary>
+        /// The port that the server is running on
+        /// </summary>
+        public int Port
+        {
+            get
+            {
+                return _listener == null ? 0 : ((IPEndPoint)_listener.LocalEndpoint).Port;
+            }
+        }
+
+        /// <summary>
         /// Method to invoke to send a log message.
         /// </summary>
         public Action<string> Logger = null;


### PR DESCRIPTION
Exposes the actual port that the server is running on for the SimpleTcpServer class.  This is useful if you initialize the server with a port of 0 so it chooses any available port, but then you need to find out the actual port after it has been created.

Not sure if this is how you want to implement it or if you even do at all, but I needed this for a project I was working on so I figured I may as well push it.