### PR TITLE
Add: AllowAnanymousIps to server settings

### DIFF
--- a/src/SuperSimpleTcp/SimpleTcpServer.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServer.cs
@@ -775,7 +775,7 @@
                     int clientPort = 0;
                     Common.ParseIpPort(clientIpPort, out clientIp, out clientPort);
 
-                    if (_settings.PermittedIPs.Count > 0 && !_settings.PermittedIPs.Contains(clientIp))
+                    if (!_settings.AllowAnanymousIPs && !_settings.PermittedIPs.Contains(clientIp))
                     {
                         Logger?.Invoke($"{_header}rejecting connection from {clientIp} (not permitted)");
                         tcpClient.Close();

--- a/src/SuperSimpleTcp/SimpleTcpServer.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServer.cs
@@ -775,7 +775,7 @@
                     int clientPort = 0;
                     Common.ParseIpPort(clientIpPort, out clientIp, out clientPort);
 
-                    if (!_settings.AllowAnanymousIPs && !_settings.PermittedIPs.Contains(clientIp))
+                    if (!_settings.AllowAnonymousIPs && !_settings.PermittedIPs.Contains(clientIp))
                     {
                         Logger?.Invoke($"{_header}rejecting connection from {clientIp} (not permitted)");
                         tcpClient.Close();

--- a/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
@@ -155,6 +155,18 @@
             }
         }
 
+        public bool AllowAnanymousIPs
+        {
+            get
+            {
+                return _allowAnanimousIPs;
+            }
+            set
+            {
+                _allowAnanimousIPs = value;
+            }
+        }
+
         #endregion
 
         #region Private-Members
@@ -166,6 +178,7 @@
         private int _idleClientEvaluationIntervalMs = 5000;
         private List<string> _permittedIPs = new List<string>();
         private List<string> _blockedIPs = new List<string>();
+        private bool _allowAnanimousIPs = true;
 
         #endregion
 

--- a/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
@@ -155,15 +155,15 @@
             }
         }
 
-        public bool AllowAnanymousIPs
+        public bool AllowAnonymousIPs
         {
             get
             {
-                return _allowAnanimousIPs;
+                return _allowAnonymousIPs;
             }
             set
             {
-                _allowAnanimousIPs = value;
+                _allowAnonymousIPs = value;
             }
         }
 
@@ -178,7 +178,7 @@
         private int _idleClientEvaluationIntervalMs = 5000;
         private List<string> _permittedIPs = new List<string>();
         private List<string> _blockedIPs = new List<string>();
-        private bool _allowAnanimousIPs = true;
+        private bool _allowAnonymousIPs = true;
 
         #endregion
 


### PR DESCRIPTION
Added Flag AllowAnanymousIPs to the SimpleTcpServerSettings in order to prevent anonymous connections even when PermittedIPs list is null or empty when needed.

scenario:
    - Sometimes we need to prevent all connections but PermittedIPs for security reasons and PermittedIPs are still empty, So there must be a flag that prevent connections in this scenario
    - Also there is a time we have some PermittedIPs but we don't need to prevent new connections, again we need a flag for this exceptional scenario