### PR TITLE
Add ToString() method to SimpleTcpClientSettings and SimpleTcpServerSettings for diagnostics

### DIFF
--- a/src/SuperSimpleTcp/SimpleTcp.xml
+++ b/src/SuperSimpleTcp/SimpleTcp.xml
@@ -429,6 +429,12 @@
             Instantiate the object.
             </summary>
         </member>
+        <member name="M:SuperSimpleTcp.SimpleTcpClientSettings.ToString">
+            <summary>
+            Convert a SimpleTcpClientSettings object to a string.
+            </summary>
+            <returns>SimpleTcpClientSettings as a string</returns>
+        </member>
         <member name="T:SuperSimpleTcp.SimpleTcpKeepaliveSettings">
             <summary>
             SimpleTcp keepalive settings.
@@ -764,6 +770,12 @@
             <summary>
             Instantiate the object.
             </summary>
+        </member>
+        <member name="M:SuperSimpleTcp.SimpleTcpServerSettings.ToString">
+            <summary>
+            Convert a SimpleTcpServerSettings object to a string.
+            </summary>
+            <returns>SimpleTcpServerSettings as a string</returns>
         </member>
         <member name="T:SuperSimpleTcp.SimpleTcpStatistics">
             <summary>

--- a/src/SuperSimpleTcp/SimpleTcpClientSettings.cs
+++ b/src/SuperSimpleTcp/SimpleTcpClientSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Security;
 
@@ -197,6 +198,30 @@ namespace SuperSimpleTcp
         #endregion
 
         #region Public-Methods
+
+        /// <summary>
+        /// Convert a SimpleTcpClientSettings object to a string.
+        /// </summary>
+        /// <returns>SimpleTcpClientSettings as a string</returns>
+        public override string ToString()
+        {
+            StringWriter details = new StringWriter();
+            details.NewLine = Environment.NewLine;
+            details.WriteLine("--- Client Settings ---");
+            details.WriteLine("  {0,-35}: {1}", "NoDelay", NoDelay);
+            details.WriteLine("  {0,-35}: {1}", "LocalEndpoint", LocalEndpoint?.ToString());
+            details.WriteLine("  {0,-35}: {1}", "StreamBufferSize", StreamBufferSize);
+            details.WriteLine("  {0,-35}: {1}", "ConnectTimeoutMs", ConnectTimeoutMs);
+            details.WriteLine("  {0,-35}: {1}", "ReadTimeoutMs", ReadTimeoutMs);
+            details.WriteLine("  {0,-35}: {1}", "IdleServerTimeoutMs", IdleServerTimeoutMs);
+            details.WriteLine("  {0,-35}: {1}", "IdleServerEvaluationIntervalMs", IdleServerEvaluationIntervalMs);
+            details.WriteLine("  {0,-35}: {1}", "ConnectionLostEvaluationIntervalMs", ConnectionLostEvaluationIntervalMs);
+            details.WriteLine("  {0,-35}: {1}", "AcceptInvalidCertificates", AcceptInvalidCertificates);
+            details.WriteLine("  {0,-35}: {1}", "MutuallyAuthenticate", MutuallyAuthenticate);
+            details.WriteLine("  {0,-35}: {1}", "UseAsyncDataReceivedEvents", UseAsyncDataReceivedEvents);
+            details.WriteLine("  {0,-35}: {1}", "CheckCertificateRevocation", CheckCertificateRevocation);
+            return details.ToString();
+        }
 
         #endregion
 

--- a/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
+++ b/src/SuperSimpleTcp/SimpleTcpServerSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Security;
 
 namespace SuperSimpleTcp
@@ -182,6 +183,29 @@ namespace SuperSimpleTcp
         #endregion
 
         #region Public-Methods
+        /// <summary>
+        /// Convert a SimpleTcpServerSettings object to a string.
+        /// </summary>
+        /// <returns>SimpleTcpServerSettings as a string</returns>
+        public override string ToString()
+        {
+            StringWriter details = new StringWriter();
+            details.NewLine = Environment.NewLine;
+            details.WriteLine("--- Server Settings ---");
+            details.WriteLine("  {0,-35}: {1}", "NoDelay", NoDelay);
+            details.WriteLine("  {0,-35}: {1}", "StreamBufferSize", StreamBufferSize);
+            details.WriteLine("  {0,-35}: {1}", "MaxConnections", MaxConnections);
+            details.WriteLine("  {0,-35}: {1}", "IdleClientTimeoutMs", IdleClientTimeoutMs);
+            details.WriteLine("  {0,-35}: {1}", "IdleClientEvaluationIntervalMs", IdleClientEvaluationIntervalMs);
+            details.WriteLine("  {0,-35}: {1}", "AcceptInvalidCertificates", AcceptInvalidCertificates);
+            details.WriteLine("  {0,-35}: {1}", "MutuallyAuthenticate", MutuallyAuthenticate);
+            details.WriteLine("  {0,-35}: {1}", "UseAsyncDataReceivedEvents", UseAsyncDataReceivedEvents);
+            details.WriteLine("  {0,-35}: {1}", "CheckCertificateRevocation", CheckCertificateRevocation);
+            details.WriteLine("  {0,-35}: {1}", "CertificateValidationCallback", CertificateValidationCallback?.ToString());
+            details.WriteLine("  {0,-35}: {1}", "PermittedIPs", string.Join(", ", PermittedIPs));
+            details.WriteLine("  {0,-35}: {1}", "BlockedIPs", string.Join(", ", BlockedIPs));
+            return details.ToString();
+        }
 
         #endregion
 


### PR DESCRIPTION
I added ToString() to the two classes for logging settings. If you are happy to merge please do so.  If not please advise, as I would like to update my fork with your latest improvements.